### PR TITLE
Added verbosity on debug - corrected Start Network issue on init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__
 .*.swp
+._.DS_Store
+.DS_Store
+.gitconfig
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ __pycache__
 ._.DS_Store
 .DS_Store
 .gitconfig
-.gitignore

--- a/embitshell.py
+++ b/embitshell.py
@@ -7,16 +7,27 @@ class EmbitShell(cmd.Cmd):
 
     prompt = "EMB> "
 
-    def __init__(self, device):
+    def __init__(self, device, debug=True):
+        self.debug = debug
+        if self.debug:
+            print("---Start Init")
         self._e = EBI(device)
+        if self.debug:
+            print("---Start Reset")
         self._e.reset()
         state = self._e.state
         self.intro = "EMBIT module {embit_module} - FW {firmware_version}\n".format(**state)
         if state['state'] == 'Online':
             self._e.network_stop()
+        if self.debug:
+            print("---Energy save")
         self._e.energy_save(0x00) # Always on
         self._params = { 'channel': 1, 'sf': 7, 'bw': 0, 'cr': 1 } # 868.100 MHz, 128 Chips/symbol, 125 kHz, 4/5
+        if self.debug:
+            print("---Operating channel")
         self._e.operating_channel(*self._params.values())
+        if self.debug:
+            print("---Start Network")
         self._e.network_start()
         super().__init__()
 
@@ -212,7 +223,7 @@ Usage: quit"""
         return True
 
 if __name__ == '__main__':
-    device = "/dev/ttyUSB0"
+    device = "/dev/ttyS6"
     try:
         device = sys.argv[1]
     except:


### PR DESCRIPTION
Added some verbosity on debug in order to find an issue on init. Enable/disable it on both files if not desired.
Incremented serial timeout on int for Start Network. The standard timeout rose an error for no answer.
The serial port is now set on ttyS6, change according to your needs.